### PR TITLE
added group_vars and template

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -4,11 +4,11 @@
   become: yes
   become_method: sudo
   tasks:
-    - name: "Stop nginx"
-      service:
-        name: nginx
-        state: stopped
-      ignore_errors: yes
+  - name: "Stop nginx"
+    service:
+      name: "{{ user }}"
+      state: stopped
+    ignore_errors: yes
 - name: "Install EPEL, PHP and Apache"
   hosts: "webhost"
   become: yes

--- a/provisioning/templates/nginx.conf.j2
+++ b/provisioning/templates/nginx.conf.j2
@@ -1,0 +1,26 @@
+user  {{ user }};
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    upstream apachepool {
+        server 127.0.0.1:81;
+        server 127.0.0.1:8008;
+    }
+
+    server {
+        listen {{ nginx.port }};
+
+        location / {
+            proxy_pass http://apachepool;
+        }
+    }
+}


### PR DESCRIPTION
I added some more directories to add the start of a more portable structure. 
group_vars/webhost dir is for all the variables for hosts: "webhost" if calling all hosts then the filename would be all. 

Added the templates dir as it can use the group_vars dir as well. 